### PR TITLE
Remove properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ docs/
 .nicegui
 # Mac
 .DS_Store
+
+
+UB-10ML.ipynb

--- a/UB-10ML-mogwai.ipynb
+++ b/UB-10ML-mogwai.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mogwai.core import MogwaiGraph\n",
+    "from mogwai.parser import graphml_to_mogwaigraph\n",
+    "from mogwai.core.traversal import MogwaiGraphTraversalSource\n",
+    "from mogwai.core.steps.statics import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = graphml_to_mogwaigraph(\n",
+    "    \"tests/documents/air-routes-latest.graphml\",\n",
+    "    node_label_key=\"labelV\",\n",
+    "    edge_label_key=\"labelE\",\n",
+    "    node_name_key=\"code\",\n",
+    ")\n",
+    "g = MogwaiGraphTraversalSource(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'labels': {'airport'},\n",
+       "  'name': 'ATL',\n",
+       "  'type': 'airport',\n",
+       "  'icao': 'KATL',\n",
+       "  'city': 'Atlanta',\n",
+       "  'desc': 'Hartsfield - Jackson Atlanta International Airport',\n",
+       "  'region': 'US-GA',\n",
+       "  'runways': 5,\n",
+       "  'longest': 12390,\n",
+       "  'elev': 1026,\n",
+       "  'country': 'US',\n",
+       "  'lat': 33.6366996765137,\n",
+       "  'lon': -84.4281005859375}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().element_map().range(1,2).to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'labels': 'route', 'dist': 809, 'id': '3749'}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V(1).outE().element_map().next().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Alicante International Airport',\n",
+       " 'Malta International Airport',\n",
+       " 'Istanbul International Airport',\n",
+       " 'Palma De Mallorca Airport',\n",
+       " 'Antalya International Airport',\n",
+       " 'Zakynthos, Dionysios Solomos Airport',\n",
+       " 'Faro Airport',\n",
+       " 'Francisco de Sa Carneiro Airport',\n",
+       " 'Kos Airport',\n",
+       " 'Tenerife South Airport',\n",
+       " 'Heraklion International Nikos Kazantzakis Airport',\n",
+       " 'Ioannis Kapodistrias International Airport',\n",
+       " 'Bari Karol Wojtyła Airport',\n",
+       " 'Catania-Fontanarossa Airport',\n",
+       " 'Girona Airport',\n",
+       " 'Vincenzo Florio Airport Trapani-Birgi',\n",
+       " 'Alghero-Fertilia Airport']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().has('city', 'Maastricht').out().values('desc').to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Daocheng', 'Bangda', 'Kangding', 'La Paz / El Alto', 'Xigaze']\n",
+      "['Daocheng', 'Bangda', 'Kangding', 'La Paz / El Alto', 'Xigaze']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(g.V().has('city','Frankfurt').union(out(), out().out()).order(desc=True).by(\"elev\").values(\"city\").dedup().limit(5).to_list().run())\n",
+    "print(g.V().has('city','Frankfurt').repeat(out()).times(2).emit().order(desc=True).by(\"elev\").values(\"city\").dedup().limit(5).to_list().run())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Nunapitchuk', 'Napaskiak']"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().has(\"country\", \"US\").repeat(outE().has(\"dist\",lt(20)).inV()).times(5).simple_path().values(\"city\").to_list().run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mogwai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/UB-10ML-mogwai.ipynb
+++ b/UB-10ML-mogwai.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -50,7 +50,7 @@
        "  'lon': -84.4281005859375}]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -70,7 +70,7 @@
        "{'labels': 'route', 'dist': 809, 'id': '3749'}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -106,7 +106,7 @@
        " 'Alghero-Fertilia Airport']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -145,13 +145,150 @@
        "['Nunapitchuk', 'Napaskiak']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "g.V().has(\"country\", \"US\").repeat(outE().has(\"dist\",lt(20)).inV()).times(5).simple_path().values(\"city\").to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().has(\"country\",\"DE\").as_(\"start\").union(\n",
+    "    has(\"runways\",eq(1)).out().out(),\n",
+    "    has(\"runways\",gte(1)).out()\n",
+    ").has('code','PMI').select(\"start\").values(\"code\").dedup().to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'labels': {'airport'},\n",
+       " 'name': 'FRA',\n",
+       " 'type': 'airport',\n",
+       " 'icao': 'EDDF',\n",
+       " 'city': 'Frankfurt',\n",
+       " 'desc': 'Frankfurt am Main',\n",
+       " 'region': 'DE-HE',\n",
+       " 'runways': 4,\n",
+       " 'longest': 13123,\n",
+       " 'elev': 364,\n",
+       " 'country': 'DE',\n",
+       " 'lat': 50.0264015198,\n",
+       " 'lon': 8.54312992096}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().has(\"country\",\"DE\").element_map().next().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['FRA',\n",
+       " 'MUC',\n",
+       " 'CGN',\n",
+       " 'HAM',\n",
+       " 'STR',\n",
+       " 'DUS',\n",
+       " 'HAJ',\n",
+       " 'DRS',\n",
+       " 'BRE',\n",
+       " 'ERF',\n",
+       " 'DTM',\n",
+       " 'NUE',\n",
+       " 'LEJ',\n",
+       " 'FMO',\n",
+       " 'FDH',\n",
+       " 'HHN',\n",
+       " 'FMM',\n",
+       " 'PAD',\n",
+       " 'NRN',\n",
+       " 'RLG',\n",
+       " 'FKB',\n",
+       " 'SCN',\n",
+       " 'LBC',\n",
+       " 'ZQW',\n",
+       " 'KSF',\n",
+       " 'XFW',\n",
+       " 'NDZ',\n",
+       " 'BER']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.V().has(\"country\",\"DE\").as_(\"start\").union(\n",
+    "    has(\"runways\",eq(1)).out().out(),\n",
+    "    has(\"runways\",gte(1)).out()\n",
+    ").has('code','PMI').select(\"start\").values(\"code\").dedup().to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = MogwaiGraph()\n",
+    "g = MogwaiGraphTraversalSource(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0, 1)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jamie = g.addV(\"profile\", \"jamie\").property(\"age\", 50).next().run()\n",
+    "adam = g.addV(\"profile\", \"adam\").property(\"age\", 38).next().run()\n",
+    "g.addE(\"knows\").from_(jamie).to_(adam).property(\"years\", 15).next().run()"
    ]
   }
  ],

--- a/UB-10ML-mogwai.ipynb
+++ b/UB-10ML-mogwai.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,15 +29,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[{'labels': {'airport'},\n",
-       "  'name': 'ATL',\n",
+       "  'name': 'airport',\n",
+       "  'labelV': 'airport',\n",
        "  'type': 'airport',\n",
+       "  'code': 'ATL',\n",
        "  'icao': 'KATL',\n",
        "  'city': 'Atlanta',\n",
        "  'desc': 'Hartsfield - Jackson Atlanta International Airport',\n",
@@ -50,7 +52,7 @@
        "  'lon': -84.4281005859375}]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -257,6 +259,30 @@
     "    has(\"runways\",eq(1)).out().out(),\n",
     "    has(\"runways\",gte(1)).out()\n",
     ").has('code','PMI').select(\"start\").values(\"code\").dedup().to_list().run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Paris', 'Barcelona', 'Madrid', 'Nice', 'Palma De Mallorca', 'Malaga', 'Tenerife Island']\n",
+      "['Paris', 'Barcelona', 'Madrid', 'Nice', 'Palma De Mallorca', 'Malaga', 'Tenerife Island']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(g.V().has(\"code\", \"DUS\").out()\\\n",
+    "\t.or_(has('country', 'ES'),has('country', 'FR'))\\\n",
+    "\t.outE().as_(\"secondflight\").inV().has(\"country\",\"US\")\\\n",
+    "\t.select(\"secondflight\").outV().values(\"city\").dedup().to_list().run())\n",
+    "print(g.V().has('code' , 'DUS').out()\\\n",
+    "\t.or_(has('country', 'ES'),has('country', 'FR')).as_(\"changeover\")\\\n",
+    "\t.out().has('country','US').select(\"changeover\").values('city').dedup().to_list().run())"
    ]
   },
   {

--- a/live_demo.ipynb
+++ b/live_demo.ipynb
@@ -179,7 +179,7 @@
     }
    ],
    "source": [
-    "g.V().has_label(\"airport\").within([\"properties\",\"city\"], [\"Brussels\", \"Maastricht\", \"Aachen\", \"Dusseldorf\"]).as_('start')\\\n",
+    "g.V().has_label(\"airport\").within(\"city\", [\"Brussels\", \"Maastricht\", \"Aachen\", \"Dusseldorf\"]).as_('start')\\\n",
     "            .outE(\"route\").as_(\"e\")\\\n",
     "            .inV()\\\n",
     "            .in_(\"contains\").has_label(\"country\").as_('dest')\\\n",

--- a/mogwai.ipynb
+++ b/mogwai.ipynb
@@ -1823,7 +1823,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g_m.V().has_label(\"airport\").within([\"properties\",\"city\"], [\"Brussels\", \"Maastricht\", \"Aachen\", \"Dusseldorf\"]).as_('start').\\\n",
+    "g_m.V().has_label(\"airport\").within(\"city\", [\"Brussels\", \"Maastricht\", \"Aachen\", \"Dusseldorf\"]).as_('start').\\\n",
     "        outE(\"route\").as_(\"e\").inV().in_(\"contains\").has_label(\"country\").as_('dest').order(desc=True).by(select('e').properties('dist')).\\\n",
     "        limit(5).select('start', 'dest').to_list().by('desc').run()"
    ]

--- a/mogwai/core/mogwaigraph.py
+++ b/mogwai/core/mogwaigraph.py
@@ -13,7 +13,7 @@ class MogwaiGraph (networkx.DiGraph):
     def add_labeled_node(self,label:set|str, name:str, properties:dict=None, **kwargs):
         #we can only insert a node by hashable value and as names and ids
         #can occur multiple times we use random values
-        label = label if isinstance(label, set) else {label}
+        label = label if isinstance(label, set) else (set(label) if isinstance(label, (list,tuple)) else {label})
         nodeID = next(self.counter)
         properties = properties or {}
         properties.update(kwargs)

--- a/mogwai/core/mogwaigraph.py
+++ b/mogwai/core/mogwaigraph.py
@@ -10,17 +10,29 @@ class MogwaiGraph (networkx.DiGraph):
         super().__init__(*args, **kwargs)
         self.counter = count(0)
 
-    def add_labeled_node(self,label:set|str, name:str, properties:dict=None):
+    def add_labeled_node(self,label:set|str, name:str, properties:dict=None, **kwargs):
         #we can only insert a node by hashable value and as names and ids
         #can occur multiple times we use random values
         label = label if isinstance(label, set) else {label}
         nodeID = next(self.counter)
-        super().add_node(nodeID, labels=label,name=name, properties=properties or {})
+        properties = properties or {}
+        properties.update(kwargs)
+        if 'name' in properties:
+            raise MogwaiGraphError("The 'name' property is reserved for the node name.")
+        elif 'labels' in properties:
+            raise MogwaiGraphError("The 'labels' property is reserved for the node labels.")
+        super().add_node(nodeID, labels=label,name=name, **properties)
         return nodeID
 
-    def add_labeled_edge(self,srcId:int,destId:int,edgeLabel:str,properties:dict=None):
+    def add_labeled_edge(self,srcId:int,destId:int,edgeLabel:str,properties:dict=None, **kwargs):
         if(self.has_node(srcId) and self.has_node(destId)):
-            super().add_edge(srcId,destId,labels=edgeLabel, properties=properties or {})
+            properties = properties or {}
+            properties.update(kwargs)
+            if 'edgeLabel' in properties:
+                raise MogwaiGraphError("The 'edgeLabel' property is reserved for the edge label.")
+            elif 'labels' in properties:
+                raise MogwaiGraphError("The 'labels' property is reserved for the node labels.")
+            super().add_edge(srcId,destId,labels=edgeLabel, **properties)
         else:
             raise MogwaiGraphError(f"Node with id {srcId if srcId<0 else destId} is not in the graph.")
 
@@ -59,25 +71,20 @@ class MogwaiGraph (networkx.DiGraph):
         self.add_edges_from(relabeled.edges(data=True))
         self.add_labeled_edge(srcId=srcId, destId=mapping[targetId], edgeLabel=edgeLabel)
 
-    def draw(self, outputfile, include_id:bool=False, prog='dot'):
-        A = networkx.nx_agraph.to_agraph(self)  # convert to a graphviz graph
-        for n in A.nodes():
-            n = A.get_node(n)
-            id = int(n.get_name())
-            if include_id:
-                n.attr["label"] = f"{id:d}:{','.join(self.nodes[id]['labels'])}:{n.attr['name']}"
-            else:
-                n.attr["label"] = f"{','.join(self.nodes[id]['labels'])}:{n.attr['name']}"
-            n.attr["tooltip"] = n.attr["properties"]
-            del n.attr["properties"]
-        for e in A.edges():
-            if(isinstance(e.attr["labels"], (set, tuple,list))):
-                e.attr['label'] = ",".join(e.attr["labels"])
-            else:
-                e.attr['label'] = e.attr['labels']
-            del e.attr['labels']
-        A.layout(prog=prog)
-        A.draw(outputfile)
+    def draw(self, outputfile, title:str="MogwaiGraph", **kwargs):
+        """
+        Draw the graph using graphviz
+        Parameters
+        ----------
+        outputfile : str
+            the file to save the graph to
+        title : str, default 'MogwaiGraph'
+            the title of the graph
+        kwargs : dict
+            additional parameters used to configure the drawing style.
+            For more details see `MogwaiGraphDrawer`
+        """
+        MogwaiGraphDrawer(self, title=title, **kwargs).draw(outputfile)
 
     @classmethod
     def modern(cls) -> 'MogwaiGraph':
@@ -86,19 +93,19 @@ class MogwaiGraph (networkx.DiGraph):
         see https://tinkerpop.apache.org/docs/current/tutorials/getting-started/
         """
         g = MogwaiGraph()
-        marko = g.add_labeled_node("Person", "marko", {"age": 29})
-        vadas = g.add_labeled_node("Person", "vadas", {"age": 27})
-        lop = g.add_labeled_node("Software", "lop", {"lang": "java"})
-        josh = g.add_labeled_node("Person", "josh", {"age": 32})
-        ripple = g.add_labeled_node("Software", "ripple", {"lang": "java"})
-        peter = g.add_labeled_node("Person", "peter", {"age": 35})
+        marko = g.add_labeled_node("Person", name="marko", age=29)
+        vadas = g.add_labeled_node("Person", name="vadas", age=27)
+        lop = g.add_labeled_node("Software", name="lop", lang="java")
+        josh = g.add_labeled_node("Person", name="josh", age=32)
+        ripple = g.add_labeled_node("Software", name="ripple", lang="java")
+        peter = g.add_labeled_node("Person", name="peter", age=35)
 
-        g.add_labeled_edge(marko, vadas, "knows", {"weight": 0.5})
-        g.add_labeled_edge(marko, josh, "knows", {"weight": 1.0})
-        g.add_labeled_edge(marko, lop, "created", {"weight": 0.4})
-        g.add_labeled_edge(josh, ripple, "created", {"weight": 1.0})
-        g.add_labeled_edge(josh, lop, "created", {"weight": 0.4})
-        g.add_labeled_edge(peter, lop, "created", {"weight": 0.2})
+        g.add_labeled_edge(marko, vadas, "knows",weight=0.5)
+        g.add_labeled_edge(marko, josh, "knows",weight=1.0)
+        g.add_labeled_edge(marko, lop, "created",weight=0.4)
+        g.add_labeled_edge(josh, ripple, "created",weight=1.0)
+        g.add_labeled_edge(josh, lop, "created",weight=0.4)
+        g.add_labeled_edge(peter, lop, "created",weight=0.2)
         return g
 
     @classmethod
@@ -110,26 +117,119 @@ class MogwaiGraph (networkx.DiGraph):
             if endTime is not None:
                 d["endTime"] = endTime
             return d
-        marko = g.add_labeled_node("person", "marko", {"location":{"san diego":t(1997,2001), "santa cruz":t(2001,2004), "brussels":t(2004,2005), "santa fe":t(2005)}})
-        stephen = g.add_labeled_node("person", "stephen", {"location":{"centreville":t(1990,2000),"dulles":t(2000,2006), "purcellvilee":t(2006)}})
-        matthias = g.add_labeled_node("person", "matthias", {"location":{"bremen":t(2004,2007), "baltimore":t(2007,2011), "oakland":t(2011,2014), "seattle":t(2014)}})
-        daniel = g.add_labeled_node("person", "daniel", {"location":{"spremberg":t(1982,2005), "kaiserslautern":t(2005,2009), "aachen":t(2009)}})
-        gremlin = g.add_labeled_node("software", "gremlin")
-        tinkergraph = g.add_labeled_node("software", "tinkergraph")
+        marko = g.add_labeled_node("Person", name="marko", location={"san diego":t(1997,2001), "santa cruz":t(2001,2004), "brussels":t(2004,2005), "santa fe":t(2005)})
+        stephen = g.add_labeled_node("Person", name="stephen", location={"centreville":t(1990,2000),"dulles":t(2000,2006), "purcellvilee":t(2006)})
+        matthias = g.add_labeled_node("Person", name="matthias", location={"bremen":t(2004,2007), "baltimore":t(2007,2011), "oakland":t(2011,2014), "seattle":t(2014)})
+        daniel = g.add_labeled_node("Person", name="daniel", location={"spremberg":t(1982,2005), "kaiserslautern":t(2005,2009), "aachen":t(2009)})
+        gremlin = g.add_labeled_node("Software", name="gremlin")
+        tinkergraph = g.add_labeled_node("Software",name="tinkergraph")
 
-        g.add_labeled_edge(marko, gremlin, "uses", {"skill":4})
-        g.add_labeled_edge(stephen, gremlin, "uses", {"skill":5})
-        g.add_labeled_edge(matthias, gremlin, "uses", {"skill":3})
-        g.add_labeled_edge(daniel, gremlin, "uses", {"skill":5})
-        g.add_labeled_edge(marko, tinkergraph, "uses", {"skill":5})
-        g.add_labeled_edge(stephen, tinkergraph, "uses", {"skill":4})
-        g.add_labeled_edge(matthias, tinkergraph, "uses", {"skill":3})
-        g.add_labeled_edge(daniel, tinkergraph, "uses", {"skill":3})
+        g.add_labeled_edge(marko, gremlin, "uses", skill=4)
+        g.add_labeled_edge(stephen, gremlin, "uses", skill=5)
+        g.add_labeled_edge(matthias, gremlin, "uses", skill=3)
+        g.add_labeled_edge(daniel, gremlin, "uses", skill=5)
+        g.add_labeled_edge(marko, tinkergraph, "uses", skill=5)
+        g.add_labeled_edge(stephen, tinkergraph, "uses", skill=4)
+        g.add_labeled_edge(matthias, tinkergraph, "uses", skill=3)
+        g.add_labeled_edge(daniel, tinkergraph, "uses", skill=3)
         g.add_labeled_edge(gremlin, tinkergraph, "traverses")
-        g.add_labeled_edge(marko, tinkergraph, "develops", {"since":2010})
-        g.add_labeled_edge(stephen, tinkergraph, "develops", {"since":2011})
-        g.add_labeled_edge(marko, gremlin, "develops", {"since":2009})
-        g.add_labeled_edge(stephen, gremlin, "develops", {"since":2010})
-        g.add_labeled_edge(matthias, gremlin, "develops", {"since":2012})
+        g.add_labeled_edge(marko, tinkergraph, "develops", since=2010)
+        g.add_labeled_edge(stephen, tinkergraph, "develops", since=2011)
+        g.add_labeled_edge(marko, gremlin, "develops", since=2009)
+        g.add_labeled_edge(stephen, gremlin, "develops", since=2010)
+        g.add_labeled_edge(matthias, gremlin, "develops", since=2012)
         return g
 
+class MogwaiGraphDrawer:
+    """
+    helper class to draw MogwaiGraphs
+    """
+    def __init__(self, g:MogwaiGraph, title:str, **kwargs):
+        """
+        Parameters
+        ----------
+        g : MogwaiGraph
+            the graph to draw
+        title : str
+            the title of the graph
+        kwargs : dict
+            additional parameters used to configure the drawing style
+            * *fontname* : str, default 'arial'
+                the font to use
+            * *fillcolor* : str, default '#ADE1FE'
+                the fill color of the vertices
+            * *edge_line_width* : int, default 3
+                the width of the edges
+            * *dash_width* : int, default 5   
+                number of dashess in the head/properties delimiter
+            * *v_limit* : int, default 10
+                the maximum number of vertices to show
+            * *e_limit* : int, default 10
+                the maximum number of edges to show
+            * *vertex_properties* : list, default None
+                the properties to display for vertices, if `None` all properties are shown
+            * *edge_properties* : list, default None
+                the properties to display for edges, if `None` all properties are shown
+            * *prog* : str, default 'dot'
+                the layout program to use
+        """
+        self.g = g
+        self.title = title
+        self.config = kwargs or {}
+        self.vertex_keys = self.config.get("vertex_properties", None)
+        self.edge_keys = self.config.get("edge_properties", None)
+
+        self.v_drawn = set()
+        self.e_drawn = set()
+
+    def _draw_vertex(self, n):
+        if len(self.v_drawn) >= self.config.get("v_limit", 10):
+            return False
+        if n[0] in self.v_drawn: return None
+        id, properties = n
+        head = f"{id:d}, {properties.pop('name')}\n{', '.join(properties.pop('labels'))}"
+        if self.vertex_keys:
+            properties = {k: v for k, v in properties.items() if k in self.vertex_keys}
+        body = "\n".join([f"{k}: {v}" for k, v in properties.items()])
+        label = f"{head}\n"+("-"*self.config.get("dash_width", 5))+f"\n{body}"
+
+        self.gviz.add_node(id,
+                    label=label,
+                    fillcolor=self.config.get('fillcolor',"#ADE1FE"),
+                    style='filled',
+                    fontname=self.config.get('fontname',"arial"))
+        self.v_drawn.add(id)
+        return True
+
+    def _draw_edge(self, e, with_vertices:bool=True):
+        if len(self.e_drawn) > self.config.get("e_limit", 10):
+            return False
+        if e[:-1] in self.e_drawn: return None
+        if with_vertices:
+            self._draw_vertex((e[0],self.g.nodes[e[0]]))
+            self._draw_vertex((e[1], self.g.nodes[e[1]]))
+        head = f"{e[2].pop('labels')}"
+        body = "\n".join([f"{k}: {v}" for k, v in e[2].items()])
+        label = f"{head}\n"+("-"*self.config.get("dash_width", 5))+f"\n{body}"
+
+        self.gviz.add_edge(e[0], e[1],
+                        label=label,
+                        style=f"setlinewidth({self.config.get('edge_line_width', 3)})",
+                        fontname=self.config.get('fontname',"arial"))
+        self.e_drawn.add(e[:-1])
+
+    def draw(self, outputfile:str):
+        try:
+            import pygraphviz
+        except ImportError:
+            raise ImportError("Please install pygraphviz to draw graphs.")
+        
+        self.gviz:pygraphviz.AGraph = networkx.nx_agraph.to_agraph(self.g)
+        for n in self.g.nodes(data=True):
+            if self._draw_vertex(n) == False:
+                break
+        for e in self.g.edges(data=True):
+            if self._draw_edge(e) == False:
+                break
+        self.gviz.layout(prog=self.config.get("prog", "dot"))
+        self.gviz.draw(outputfile)

--- a/mogwai/core/steps/base_steps.py
+++ b/mogwai/core/steps/base_steps.py
@@ -13,6 +13,8 @@ class Step:
     SUPPORTS_BY = 1<<3
     SUPPORTS_ANON_BY = 1<<4 | SUPPORTS_BY
     SUPPORTS_MULTIPLE_BY = 1<<5 | SUPPORTS_BY
+    SUPPORTS_FROMTO = 1<<6
+
     def __init__(self, traversal:'Traversal', flags:int=0):
         self.traversal = traversal
         self.flags = flags
@@ -35,6 +37,9 @@ class Step:
     @property
     def supports_multiple_by(self):
         return (self.flags & Step.SUPPORTS_MULTIPLE_BY)==Step.SUPPORTS_MULTIPLE_BY
+    @property
+    def supports_fromto(self):
+        return (self.flags & Step.SUPPORTS_FROMTO)==Step.SUPPORTS_FROMTO
 
     @abstractmethod
     def __call__(self, traversers: Iterable['Traverser']) -> Iterable['Traverser']:

--- a/mogwai/core/steps/filter_steps.py
+++ b/mogwai/core/steps/filter_steps.py
@@ -1,5 +1,5 @@
 from .base_steps import FilterStep
-from typing import List, Set, Any, Generator, Iterable
+from typing import List, Set, Tuple, Any, Generator, Iterable
 from mogwai.core import Traversal, AnonymousTraversal
 from mogwai.core import Traverser
 from mogwai.core.traverser import Value, Property
@@ -90,6 +90,17 @@ class Has(FilterStep):
                 self._filter = lambda t: self.value(indexer(self.traversal._get_element(t)))
             else:
                 self._filter = lambda t: indexer(self.traversal._get_element(t)) == self.value
+
+class HasWithin(FilterStep):
+    """
+    Similar to `Has`, but with multiple options for the value
+    """
+    def __init__(self, traversal:Traversal, key:str|List[str], valueOptions:List|Tuple):
+        super().__init__(traversal)
+        self.key = key
+        self.valueOptions = valueOptions
+        indexer = (lambda t: t.get) if key=="id" else get_dict_indexer(key, _NA)
+        self._filter = lambda t: indexer(self.traversal._get_element(t)) in self.valueOptions
 
 class HasNot(FilterStep):
     def __init__(self, traversal:Traversal, key:str|List[str]):

--- a/mogwai/core/steps/filter_steps.py
+++ b/mogwai/core/steps/filter_steps.py
@@ -351,11 +351,6 @@ def has_name(name: str):
     return Has(None, "name", value=name)
 
 @as_traversal_function
-def has_property(key: str|List[str], value:Any=None):
-    key = (["properties"]+key) if type(key) is list else ["properties", key]
-    return Has(None,key, value=value)
-
-@as_traversal_function
 def has_label(label: str):
     return Contains(None, "labels", value=label)
 

--- a/mogwai/core/steps/map_steps.py
+++ b/mogwai/core/steps/map_steps.py
@@ -38,7 +38,8 @@ class Values(MapStep):
                 #First, we need to discover the keys
                 if type(t)==Traverser:
                     obj = self.traversal._get_element(t)
-                    keys = ['name'] + [['properties', key] for key in obj['properties'].keys()]
+                    keys = set(obj.keys())
+                    keys.remove("labels")
                 else:
                     obj = t.val
                     if isinstance(obj, dict):
@@ -92,13 +93,14 @@ class Properties(MapStep):
                 #First, we need to discover the keys
                 if type(t)==Traverser:
                     obj = self.traversal._get_element(t)
-                    keys = ['name'] + [['properties', key] for key in obj['properties'].keys()]
+                    keys = set(obj.keys())
+                    keys.remove("labels")
                 else:
                     obj = t.val
                     if isinstance(obj, dict):
                         keys = obj.keys()
                     else:
-                        return
+                        return None
                 indexers = [get_dict_indexer(key, _NA) for key in keys]
                 keys = [(tuple(key) if type(key) is list else key) for key in keys]
                 for i in range(len(keys)):

--- a/mogwai/core/steps/map_steps.py
+++ b/mogwai/core/steps/map_steps.py
@@ -30,7 +30,6 @@ class Key(MapStep):
 class Values(MapStep):
     def __init__(self, traversal:Traversal, *keys:str|List[str]):
         super().__init__(traversal=traversal)
-        keys = [["properties", *key] if type(key) is list else (['properties', key] if key!='name' else key) for key in keys]
         self.indexers = [get_dict_indexer(key, _NA) for key in keys]
         self.keys = [(tuple(key) if type(key) is list else key) for key in keys]
         if len(keys)==0:
@@ -85,7 +84,6 @@ class Values(MapStep):
 class Properties(MapStep):
     def __init__(self, traversal:Traversal, *keys:str|List[str]):
         super().__init__(traversal=traversal)
-        keys = [["properties", *key] if type(key) is list else (['properties', key] if key!='name' else key) for key in keys]
         self.indexers = [get_dict_indexer(key, _NA) for key in keys]
         self.keys = [(tuple(key) if type(key) is list else key) for key in keys]
         if len(keys)==0:

--- a/mogwai/core/steps/map_steps.py
+++ b/mogwai/core/steps/map_steps.py
@@ -450,6 +450,14 @@ class Aggregate(MapStep):
             return super().__call__(traversers)
 
 @as_traversal_function
+def element_map(*keys:str) -> 'Traversal':
+    if len(keys) == 1:
+        keys = keys[0]
+    elif len(keys)==0:
+        keys=None
+    return ElementMap(None, keys)
+
+@as_traversal_function
 def value():
     return Value(None)
 

--- a/mogwai/core/steps/start_steps.py
+++ b/mogwai/core/steps/start_steps.py
@@ -1,8 +1,8 @@
-from .base_steps import Step
+from .base_steps import Step, SideEffectStep
 from mogwai.core import MogwaiGraph
 from mogwai.core.traverser import Traverser
 from mogwai.core.traversal import Traversal
-from typing import List, Tuple
+from typing import List, Tuple, Set
 from ..exceptions import GraphTraversalError
 
 class V(Step):
@@ -29,7 +29,25 @@ class V(Step):
                     else:
                         raise GraphTraversalError(f"No node with id {v}.")
         return traversers
+
+class AddV(SideEffectStep):
+    def __init__(self, graph:MogwaiGraph, labels:str|Set[str], name:str="", **kwargs):
+        super(SideEffectStep, self).__init__(None, flags=Step.ISSTART)
+        self.graph = graph
+        self.name = name
+        self.properties = kwargs
+        self.labels = {labels} if isinstance(labels, str) else (set(labels) if isinstance(labels, (list,tuple)) else labels)
     
+    def set_traversal(self, traversal:Traversal):
+        self.traversal = traversal
+    
+    def __call__(self, traversers:List[Traverser]) -> List[Traverser]:
+        if len(traversers)>0:
+            raise GraphTraversalError("Cannot perform AddV step on a non-empty Traversal.")
+        v = self.graph.add_labeled_node(self.labels, name=self.name, **self.properties)
+        traversers.append(Traverser(v, track_path=self.traversal.needs_path))
+        return traversers
+
 class E(Step):
     def __init__(self, graph:MogwaiGraph, init:Tuple[int]|List[Tuple[int]]):
         super().__init__(None, flags=Step.ISSTART)
@@ -53,4 +71,26 @@ class E(Step):
                         traversers.append(Traverser(*e, track_path=self.traversal.needs_path))
                     else:
                         raise GraphTraversalError(f"No edge from {e[0]} to {e[1]}.")
+        return traversers
+
+class AddE(SideEffectStep):
+    def __init__(self, graph:MogwaiGraph, relation:str, from_:int=None, to_:int=None, **kwargs):
+        super(SideEffectStep, self).__init__(None, flags=Step.ISSTART|Step.SUPPORTS_FROMTO)
+        self.graph = graph
+        self.relation = relation
+        self.from_, self.to_ = from_, to_
+        self.properties = kwargs
+            
+    def set_traversal(self, traversal:Traversal):
+        self.traversal = traversal
+    
+    def build(self):
+        if self.from_ is None or self.to_ is None:
+            raise GraphTraversalError("AddE step requires both from_ and to_ parameters. Did you forget a from_() or to() step?")
+    
+    def __call__(self, traversers:List[Traverser]) -> List[Traverser]:
+        if len(traversers)>0:
+            raise GraphTraversalError("Cannot perform AddE step on a non-empty Traversal.")
+        self.graph.add_labeled_edge(self.from_, self.to_, self.relation, **self.properties)
+        traversers.append(Traverser(self.from_, self.to_, track_path=self.traversal.needs_path))
         return traversers

--- a/mogwai/core/steps/statics.py
+++ b/mogwai/core/steps/statics.py
@@ -1,5 +1,5 @@
 from .branch_steps import branch, repeat
-from .filter_steps import has, has_not, has_id, has_label, has_name, has_property, contains, filter, simple_path, limit, dedup, and_, or_, not_
+from .filter_steps import has, has_not, has_id, has_label, has_name, contains, filter, simple_path, limit, dedup, and_, or_, not_
 from .flatmap_steps import out, outE, outV, in_, inE, inV, both, bothV, bothE
 from .map_steps import properties, value, values, key, select, path, count, min_, max_, mean, sum_
 from .modulation_steps import as_, until, emit

--- a/mogwai/core/steps/statics.py
+++ b/mogwai/core/steps/statics.py
@@ -1,7 +1,22 @@
-from .branch_steps import branch, repeat
+from .branch_steps import branch, repeat, union
 from .filter_steps import has, has_not, has_id, has_label, has_name, contains, filter, simple_path, limit, dedup, and_, or_, not_
 from .flatmap_steps import out, outE, outV, in_, inE, inV, both, bothV, bothE
-from .map_steps import properties, value, values, key, select, path, count, min_, max_, mean, sum_
+from .map_steps import properties, value, values, key, select, path, count, min_, max_, mean, sum_, element_map
 from .modulation_steps import as_, until, emit
 from .predicates import *
 from .scope import Scope
+
+#I'm reasonably sure that this is NOT good practice, but it works, so ¯\_(ツ)_/¯
+def add_camel_case_aliases(module_globals):
+    """Add camelCase aliases for all snake_case callables in the module's globals."""
+    camel_case_aliases = {}
+    for name, obj in module_globals.items():
+        if callable(obj) and '_' in name:  # Only convert callable objects with underscores
+            components = name.split('_')
+            camel_case_name = components[0] + ''.join(x.capitalize() for x in components[1:])
+            if name.endswith('_'):
+                camel_case_name += '_'
+            if camel_case_name != name:
+                camel_case_aliases[camel_case_name] = obj
+    module_globals.update(camel_case_aliases)
+add_camel_case_aliases(globals())

--- a/mogwai/core/steps/terminal_steps.py
+++ b/mogwai/core/steps/terminal_steps.py
@@ -60,7 +60,7 @@ class AsGenerator(Step):
         if self.by:
             get_property = get_dict_indexer(self.by)
         def convert_func(trav):
-            if isinstance(trav, Iterable):
+            if isinstance(trav, (list, tuple, set)):
                 #we've got nested data...
                 logger.debug("Recursively listing traversers...")
                 return [convert_func(t) for t in trav]
@@ -77,7 +77,6 @@ class AsGenerator(Step):
                 return trav.value
             else:
                 return trav
-
         return (convert_func(trav) for trav in traversers)
 
 class HasNext(Step):

--- a/mogwai/core/steps/terminal_steps.py
+++ b/mogwai/core/steps/terminal_steps.py
@@ -104,3 +104,11 @@ class AsPath(Step):
         else:
             paths = [t.path for t in traversers]
         return paths
+    
+class Iterate(AsGenerator):
+    def __init__(self, traversal:Iterable):
+        super().__init__(traversal)
+        self.flags = Step.ISTERMINAL
+    
+    def __call__(self, traversers:Iterable[Traverser]|Iterable[Value]|Iterable[Property]) -> None:
+        for _ in traversers: pass #TODO: optimize this: we needn't execute this if there are no side effects!

--- a/mogwai/core/traversal.py
+++ b/mogwai/core/traversal.py
@@ -2,7 +2,7 @@ from typing import Any, List, Set, Tuple, Callable, Iterable, TYPE_CHECKING
 from .mogwaigraph import MogwaiGraph
 from mogwai.core.traverser import Traverser
 from mogwai.core.steps.scope import Scope
-from mogwai.decorators import with_call_order
+from mogwai.decorators import with_call_order, add_camel_case_methods
 from .exceptions import QueryError
 from mogwai.config import DEFAULT_ITERATION_DEPTH
 from mogwai.config import USE_MULTIPROCESSING
@@ -11,8 +11,7 @@ from .steps.base_steps import Step
 import logging
 logger = logging.getLogger("Mogwai")
 
-
-
+@add_camel_case_methods
 class Traversal:
     def __init__(self, source:'MogwaiGraphTraversalSource', start:'Step', optimize:bool=True, eager:bool=False, query_verify:bool=False, use_mp:bool=False):
         if start is None:

--- a/mogwai/core/traversal.py
+++ b/mogwai/core/traversal.py
@@ -325,6 +325,11 @@ class Traversal:
             raise TypeError("Branch is only allowed to be given MapSteps")
         self._add_step(Branch(self,branchFunc))
         return self
+    
+    def union(self, *traversals:'AnonymousTraversal') -> 'Traversal':
+        from .steps.branch_steps import Union
+        self._add_step(Union(self, *traversals))
+        return self
 
     ## ===== MODULATION STEPS ======
     def option(self,branchKey,OptionStep:'AnonymousTraversal') -> 'Traversal':

--- a/mogwai/core/traversal.py
+++ b/mogwai/core/traversal.py
@@ -41,6 +41,12 @@ class Traversal:
         return self
 
     def has(self, *args) -> 'Traversal':
+        """
+        Filter traversers based on whether they have the given properties.
+        * If one argument is given, it is assumed to be a key, and the step checks if a property with that key exists, regardless of its value.
+        * If two arguments are given, it is assumed to be a key and a value, and the step checks if a property with that key exists and has the given value.
+        * If three arguments are given, the first argument is assumed to be a label, and the step checks if a property with the given key and value exists on an element with that label. 
+        """
         #if `key` is a list, like ['a', 'b'], the value will be compared to data['a']['b']
         from .steps.filter_steps import Has
         if len(args)==1:
@@ -76,8 +82,15 @@ class Traversal:
         self._add_step(HasId(self, *ids))
         return self
 
-    def has_name(self, name: str) -> 'Traversal':
-        return self.has("name", name)
+    def has_name(self, *name: str) -> 'Traversal':
+        if len(name) == 0:
+            raise QueryError("No name provided for `has_name`")
+        elif len(name) == 1:
+            return self.has("name", name[0])
+        elif len(name) > 1:
+            from .steps.filter_steps import HasWithin
+            self._add_step(HasWithin(self, "name", name))
+            return self
 
     def has_label(self, label: str|Set[str]) -> 'Traversal':
         if isinstance(label, set):
@@ -218,6 +231,15 @@ class Traversal:
     def mean(self, scope:Scope=Scope.global_) -> 'Traversal':
         from .steps.map_steps import Aggregate
         self._add_step(Aggregate(self, "mean", scope))
+        return self
+
+    def element_map(self, *keys:str) -> 'Traversal':
+        from .steps.map_steps import ElementMap
+        if len(keys) == 1:
+            keys = keys[0]
+        elif len(keys)==0:
+            keys=None
+        self._add_step(ElementMap(self, keys))
         return self
 
     ## ===== FLATMAP STEPS ======

--- a/mogwai/decorators/__init__.py
+++ b/mogwai/decorators/__init__.py
@@ -1,2 +1,2 @@
 from .decorators import as_traversal_function
-from .decorators import with_call_order
+from .decorators import with_call_order, add_camel_case_methods

--- a/mogwai/decorators/decorators.py
+++ b/mogwai/decorators/decorators.py
@@ -28,3 +28,16 @@ def with_call_order(func):
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs, _order=list(kwargs.keys()))
     return wrapper
+
+def add_camel_case_methods(cls):
+    for attr_name in dir(cls):
+        if not attr_name.startswith('_'):  # skip private and special methods
+            attr = getattr(cls, attr_name)
+            if callable(attr):
+                splitted = attr_name.split("_")
+                camel_case_name = splitted[0] + ''.join([word.capitalize() for word in splitted[1:]])
+                if attr_name.endswith("_"):
+                    camel_case_name += "_"
+                if attr_name != camel_case_name:
+                    setattr(cls, camel_case_name, attr)
+    return cls

--- a/mogwai/parser/excel_converter.py
+++ b/mogwai/parser/excel_converter.py
@@ -15,19 +15,17 @@ class EXCELGraph(MogwaiGraph):
                 raise FileNotFoundError(f"No such file or directory: '{file:s}'")
             self.file = file
             name = name or os.path.basename(file)
-            self.root = self.add_labeled_node(label=EXCELGraph.LABEL, name=name, properties=get_file_stats(self.file))
+            self.root = self.add_labeled_node(label=EXCELGraph.LABEL, name=name, **get_file_stats(self.file))
             self.construct()
 
     def construct(self):
         dic = excel_to_dic(self.file)
         sheets = dic.pop("sheets")
-        self.nodes[self.root]["properties"].update({"metadata": dic,
+        self.nodes[self.root].update({"metadata": dic,
                                 "number_of_sheets": len(sheets)})
         for sheet in sheets:
-            node = self.add_labeled_node(label="EXCELSheet", name=sheet["name"], properties=sheet)
+            node = self.add_labeled_node(label="EXCELSheet", name=sheet.pop('name'), **sheet)
             self.add_labeled_edge(self.root, node, "HAS_SHEET")
-        
-        
 
 def excel_to_dic(path:str) -> dict:
     workbook = load_workbook(path)

--- a/mogwai/parser/filesystem.py
+++ b/mogwai/parser/filesystem.py
@@ -28,7 +28,7 @@ def get_subgraph(file:str) -> MogwaiGraph:
         
 
 IGNORED_DIRECTORIES = [".git", "__pycache__"]       
-FILETYPES_TO_UNFOLD = (".pdf", ".pptx", ".xlsx")    #TODO ".rdf", ".xml"
+FILETYPES_TO_UNFOLD = (".pdf", ".pptx", ".xlsx")
 
 class FileSystemGraph(MogwaiGraph):
 
@@ -44,14 +44,14 @@ class FileSystemGraph(MogwaiGraph):
             if current_path.endswith(FILETYPES_TO_UNFOLD):
                 if(parent_node is None): raise ValueError("A filesystem graph can not be just one file")
                 subgraph = get_subgraph(current_path)
-                self.merge_subgraph(subgraph, parent_node, subgraph.root, "has_file")  
+                self.merge_subgraph(subgraph, parent_node, subgraph.root, "HAS_FILE")  
             else:
-                node = self.add_labeled_node(name=os.path.basename(current_path), properties=get_file_stats(current_path), label="File")
-                if(parent_node is not None): self.add_labeled_edge(parent_node, node, "has_file")
+                node = self.add_labeled_node(name=os.path.basename(current_path), **get_file_stats(current_path), label="File")
+                if(parent_node is not None): self.add_labeled_edge(parent_node, node, "HAS_FILE")
 
         elif os.path.isdir(current_path):
-            current_node = self.add_labeled_node(name=os.path.basename(current_path), properties={}, label="Directory")
-            if(parent_node is not None): self.add_labeled_edge(parent_node, current_node, "has_folder")
+            current_node = self.add_labeled_node(name=os.path.basename(current_path), label="Directory")
+            if(parent_node is not None): self.add_labeled_edge(parent_node, current_node, "HAS_FOLDER")
             for item in os.listdir(current_path):
                 if (not item in IGNORED_DIRECTORIES):
                     item_path = os.path.join(current_path, item)

--- a/mogwai/parser/graphml_converter.py
+++ b/mogwai/parser/graphml_converter.py
@@ -9,7 +9,41 @@ logger = logging.getLogger("Mogwai")
 def graphml_to_mogwaigraph(file:str, node_label_key:str|Callable[[dict],str], node_name_key:str|Callable[[dict],str],
                            edge_label_key:str|Callable[[dict],str]=None,
                            default_node_label:str='Na', default_edge_label:str='Na', default_node_name:str='Na',
-                           include_id:bool|str=False)->MogwaiGraph:
+                           include_id:bool|str=False, keep:bool=True)->MogwaiGraph:
+    """
+    Converts GraphML file to MogwaiGraph object.
+
+    Parameters
+    ----------
+    file : str
+        Path to the GraphML file.
+    node_label_key : str or Callable[[dict],str]
+        Key to use for the node label. If a string, the value of the key is used as the label.
+        If a function, it should take a dictionary of node data and return a string.
+    node_name_key : str or Callable[[dict],str]
+        Key to use for the node name. If a string, the value of the key is used as the name.
+        If a function, it should take a dictionary of node data and return a string.
+    edge_label_key : str or Callable[[dict],str], optional
+        Key to use for the edge label. If a string, the value of the key is used as the label.
+        If a function, it should take a dictionary of edge data and return a string.
+        If None, the node_label_key is used.
+    default_node_label : str, optional
+        Default label to use for nodes that do not have a property corresponding to `node_label_key`.
+    default_edge_label : str, optional
+        Default label to use for edges that do not have a property corresponding to `edge_label_key`.
+    default_node_name : str, optional
+        Default name to use for nodes that do not have a property corresponding to `node_name_key`.
+    include_id : bool or str, optional
+        If True, the node id is included in the data dictionary of each node.
+        If a string, the node id is included in the data dictionary with the given key.
+    keep : bool, optional
+        If True, the labels and names are kept as properties in the node data dictionary. If False, they are removed.
+    
+    Returns
+    -------
+    MogwaiGraph
+        The graph object
+    """
     gml = nx.read_graphml(file)
     if not gml.is_directed():
         raise MogwaiGraphError("Can not import undirected graphml graph")
@@ -21,7 +55,7 @@ def graphml_to_mogwaigraph(file:str, node_label_key:str|Callable[[dict],str], no
     missing_label_count = count()
     if type(node_label_key) is str:
         def node_label_func(data:dict):
-            if node_label_key in data: return data.pop(node_label_key)
+            if node_label_key in data: return data[node_label_key] if keep else data.pop(node_label_key)
             else:
                 next(missing_label_count)
                 return default_node_label
@@ -30,7 +64,7 @@ def graphml_to_mogwaigraph(file:str, node_label_key:str|Callable[[dict],str], no
     missing_name_count = count()
     if type(node_name_key) is str:
         def node_name_func(data:dict):
-            if node_name_key in data: return data.pop(node_name_key)
+            if node_name_key in data: return data[node_name_key] if keep else data.pop(node_name_key)
             else:
                 next(missing_name_count)
                 return default_node_name
@@ -40,7 +74,7 @@ def graphml_to_mogwaigraph(file:str, node_label_key:str|Callable[[dict],str], no
     missing_edge_count = count()
     if type(edge_label_key) is str:
         def edge_label_func(data:dict):
-            if edge_label_key in data: return data.pop(edge_label_key)
+            if edge_label_key in data: return data[edge_label_key] if keep else data.pop(edge_label_key)
             else:
                 next(missing_edge_count)
                 return default_edge_label

--- a/mogwai/parser/graphml_converter.py
+++ b/mogwai/parser/graphml_converter.py
@@ -51,10 +51,10 @@ def graphml_to_mogwaigraph(file:str, node_label_key:str|Callable[[dict],str], no
     for node, data in gml.nodes(data=True):
         if(include_id):
             data[include_id] = node
-        assigned_id = g.add_labeled_node(label=node_label_func(data), name=node_name_func(data), properties=data)
+        assigned_id = g.add_labeled_node(label=node_label_func(data), name=node_name_func(data), **data)
         node_to_id_map[node] = assigned_id
     for node1, node2, data in gml.edges(data=True):
-        g.add_labeled_edge(srcId=node_to_id_map[node1] , destId=node_to_id_map[node2], edgeLabel=edge_label_func(data), properties=data)
+        g.add_labeled_edge(srcId=node_to_id_map[node1] , destId=node_to_id_map[node2], edgeLabel=edge_label_func(data), **data)
     
     missing_edge_count = next(missing_edge_count)
     missing_name_count = next(missing_name_count)

--- a/mogwai/parser/pdfgraph.py
+++ b/mogwai/parser/pdfgraph.py
@@ -11,7 +11,7 @@ class PDFGraph(MogwaiGraph):
                 raise FileNotFoundError(f"No such file or directory: '{file:s}'")
             self.file = file
             name = name or os.path.basename(file)
-            self.root = self.add_labeled_node(label=PDFGraph.LABEL, name=name, properties=get_file_stats(self.file))
+            self.root = self.add_labeled_node(label=PDFGraph.LABEL, name=name, **get_file_stats(self.file))
             self.construct()
 
     def construct(self):
@@ -22,7 +22,7 @@ class PDFGraph(MogwaiGraph):
                      "creator": meta.creator,
                      "subject": meta.subject,
                      "title": meta.title}
-        self.nodes[self.root]["properties"].update({"metadata": meta_dict,
+        self.nodes[self.root].update({"metadata": meta_dict,
                                 "number_of_pages": len(reader.pages)})
         titles = []
         def collect_titles(obj):
@@ -33,5 +33,5 @@ class PDFGraph(MogwaiGraph):
                     collect_titles(child)
         collect_titles(reader.outline)
         for title in titles:
-            node = self.add_labeled_node(label="PDFTitle", name=title[0], properties=dict(page_number=title[1]))
+            node = self.add_labeled_node(label="PDFTitle", name=title[0], page_number=title[1])
             self.add_labeled_edge(self.root, node, "HAS_CONTENT")

--- a/mogwai/parser/powerpoint_converter.py
+++ b/mogwai/parser/powerpoint_converter.py
@@ -25,7 +25,7 @@ class PPGraph(MogwaiGraph):
                 raise FileNotFoundError(f"No such file or directory: '{file:s}'")
             self.file = file
             name = name or os.path.basename(file)
-            self.root = self.add_labeled_node(label=PPGraph.LABEL, name=name, properties=get_file_stats(self.file))
+            self.root = self.add_labeled_node(label=PPGraph.LABEL, name=name, **get_file_stats(self.file))
             self.construct()
 
     def construct(self):
@@ -33,11 +33,18 @@ class PPGraph(MogwaiGraph):
         meta_dict = {"titel": dic["title"],
                      "author": dic["author"],
                      "created": dic["created"]}     
-        self.nodes[self.root]["properties"].update({"metadata": meta_dict,
+        self.nodes[self.root].update({"metadata": meta_dict,
                                 "number_of_slides": len(dic["slides"])})
         
         for slide in dic["slides"]:
-            node = self.add_labeled_node(label="PPPage", name="page" + str(slide["page"]), properties=slide)
+            if 'name' in slide:
+                name = slide['name']
+                if len(name) == 0:
+                    name = "page" + str(slide["page"])
+                del slide['name']
+            else:
+                name = "page" + str(slide["page"])
+            node = self.add_labeled_node(label="PPPage", name=name, **slide)
             self.add_labeled_edge(self.root, node, "HAS_PAGE")
 
     

--- a/tests/query_parsing.ipynb
+++ b/tests/query_parsing.ipynb
@@ -151,7 +151,7 @@
    ],
    "source": [
     "#steps in PyMogwai\n",
-    "steps_in_pymogwai = {\"filter\", \"has\", \"hasId\", \"hasName\", \"hasLabel\", \"hasProperty\", \"is\",\n",
+    "steps_in_pymogwai = {\"filter\", \"has\", \"hasId\", \"hasName\", \"hasLabel\", \"is\",\n",
     "                     \"contains\", \"within\", \"simplePath\", \"limit\", \"dedup\", \"identity\", \"name\",\n",
     "                     \"value\", \"label\", \"properties\", \"select\", \"order\", \"count\", \"path\",\n",
     "                     \"max\", \"min\", \"sum\", \"mean\", \"out\", \"outE\", \"outV\", \"inE\", \"inV\",\n",
@@ -843,6 +843,53 @@
     "\t\t\tf.write(f\"{query}\\n\")\n",
     "\tprint(f\"Saved {counter} queries\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing wrappers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Any, Callable\n",
+    "def parameterizable_step(func:Callable):\n",
+    "    def check_is_hello(x:Any):\n",
+    "        if x == 'hello':\n",
+    "            return True\n",
+    "        elif isinstance(x, (list,tuple)):\n",
+    "            return any(check_is_hello(i for i in x))\n",
+    "        elif isinstance(x, dict):\n",
+    "            return any(check_is_hello(i for i in x.values()))\n",
+    "        return False\n",
+    "\n",
+    "    def wrapper(instance, *args, **kwargs):\n",
+    "        if check_is_hello(args) or check_is_hello(kwargs):\n",
+    "            #use a parameter\n",
+    "            return instance._sayhello(*args, **kwargs)\n",
+    "        else: return func(*args, **kwargs)\n",
+    "    return wrapper\n",
+    "\n",
+    "class Test:\n",
+    "\t@parameterizable_step\n",
+    "\tdef _sayhello(self, *args, **kwargs):\n",
+    "\t\tprint(\"Hello\", args, kwargs)\n",
+    "\n",
+    "\tdef sayhello(self, *args, **kwargs):\n",
+    "\t\tprint(args, kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -861,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/tests/test_airroutes.py
+++ b/tests/test_airroutes.py
@@ -5,7 +5,7 @@ from mogwai.parser.graphml_converter import graphml_to_mogwaigraph
 from tests.basetest import BaseTest
 
 
-class TestSteps(BaseTest):
+class TestAirroutes(BaseTest):
     """
     test Steps
     """

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -5,7 +5,7 @@ from mogwai.parser.filesystem import FileSystemGraph as FSG
 from .basetest import BaseTest
 
 
-class TestTraverser(BaseTest):
+class TestBranch(BaseTest):
     """
     test the traverser
     """

--- a/tests/test_complex_queries.py
+++ b/tests/test_complex_queries.py
@@ -5,7 +5,7 @@ from mogwai.core.traversal import MogwaiGraphTraversalSource
 from .basetest import BaseTest
 
 
-class TestSteps(BaseTest):
+class TestQueries(BaseTest):
     def setUp(self):
         super().setUp()
 

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -5,7 +5,7 @@ from mogwai.parser.excel_converter import EXCELGraph
 from .basetest import BaseTest
 
 
-class TestGraph(BaseTest):
+class TestExcel(BaseTest):
     def setUp(self):
         super().setUp()
         # Initialize a sample file system structure for testing
@@ -16,10 +16,10 @@ class TestGraph(BaseTest):
         nodes = graph.get_nodes("EXCELFile", "test_excel.xlsx")
         self.assertTrue(len(nodes) == 1, "Incorrect number of test_excel.xlsx nodes")
         self.assertTrue(
-            nodes[0][1]["properties"]["metadata"]["title"] == "BspTitel", "Title wrong"
+            nodes[0][1]["metadata"]["title"] == "BspTitel", "Title wrong"
         )
         self.assertTrue(
-            graph.get_nodes("EXCELSheet", "sheet1")[0][1]["properties"]["column2"]["2"]
+            graph.get_nodes("EXCELSheet", "sheet1")[0][1]["column2"]["2"]
             == "b4",
             "Wrong column element",
         )

--- a/tests/test_extra_steps.py
+++ b/tests/test_extra_steps.py
@@ -119,7 +119,8 @@ class TestSteps(BaseTest):
         print("Query:", query.print_query())
         res = query.run()
         print("Result:", res)
-        self.assertEqual(res, {'labels': {'Person'}, 'name': 'marko', 'age': 29})
+        self.assertTrue(len(res) == 1, "Query should have returned only one result")
+        self.assertEqual(res[0], {'labels': {'Person'}, 'name': 'marko', 'age': 29})
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_extra_steps.py
+++ b/tests/test_extra_steps.py
@@ -66,7 +66,6 @@ class TestSteps(BaseTest):
         print("Result:", res)
         print(g.V().has_label("Person").outE("created").count().to_list().run())
 
-    @unittest.skip("fails as of 2024-08-15")
     def test_in(self):
         g = Trav.MogwaiGraphTraversalSource(self.modern)
         query = (

--- a/tests/test_extra_steps.py
+++ b/tests/test_extra_steps.py
@@ -113,6 +113,13 @@ class TestSteps(BaseTest):
         print("Result:", res)
         self.assertTrue(len(res) == 1, "Incorrect query result!")
 
+    def test_element_map(self):
+        g = Trav.MogwaiGraphTraversalSource(self.modern)
+        query = g.V(0).element_map().to_list()
+        print("Query:", query.print_query())
+        res = query.run()
+        print("Result:", res)
+        self.assertEqual(res, {'labels': {'Person'}, 'name': 'marko', 'age': 29})
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_extra_steps.py
+++ b/tests/test_extra_steps.py
@@ -19,7 +19,7 @@ class TestSteps(BaseTest):
         query = (
             g.V()
             .has_label("Directory")
-            .filter_(out("has_file").has_label("PDFFile"))
+            .filter_(out("HAS_FILE").has_label("PDFFile"))
             .to_list(by="name")
         )
         print("Query:", query.print_query())
@@ -86,7 +86,7 @@ class TestSteps(BaseTest):
     def test_local(self):
         g = Trav.MogwaiGraphTraversalSource(self.crew)
         query = (
-            g.V().has_label("person").local(out("develops").limit(1).name()).to_list()
+            g.V().has_label("Person").local(out("develops").limit(1).name()).to_list()
         )
         print("Query:", query.print_query())
         res = query.run()

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -25,7 +25,7 @@ class TestFileSystem(BaseTest):
 
         readme_node = readme_nodes[0]  # select the first tuple
         print("Readme node:", type(readme_node))
-        properties = readme_node[1]["properties"]
+        properties = readme_node[1]
         self.assertTrue(
             "File" in readme_node[1]["labels"],
             "Incorrect or missing label for README.md",

--- a/tests/test_graphml.py
+++ b/tests/test_graphml.py
@@ -27,7 +27,7 @@ class TestGraphml(BaseTest):
         )
         print(g.nodes(data=True))
         self.assertTrue(
-            g.nodes(data=True)[0]["properties"]["id"] == "n0",
+            g.nodes(data=True)[0]["id"] == "n0",
             "Incorrect import of graphml node id",
         )
         self.assertTrue(

--- a/tests/test_gremlinpython.py
+++ b/tests/test_gremlinpython.py
@@ -8,7 +8,7 @@ from .basetest import BaseTest
 
 
 @unittest.skip("Skipping tests")
-class TestFileServer(BaseTest):
+class TestGremlinPython(BaseTest):
     def setUp(self):
         super().setUp()
         self.air_routes_small = os.path.join(

--- a/tests/test_live_demo.py
+++ b/tests/test_live_demo.py
@@ -5,7 +5,7 @@ from mogwai.core.traversal import MogwaiGraphTraversalSource
 from .basetest import BaseTest
 
 
-class TestSteps(BaseTest):
+class TestLiveDemo(BaseTest):
     def setUp(self):
         from mogwai.parser import graphml_to_mogwaigraph
 
@@ -98,7 +98,7 @@ class TestSteps(BaseTest):
             self.g.V()
             .has_label("airport")
             .within(
-                ["properties", "city"],
+                "city",
                 ["Brussels", "Maastricht", "Aachen", "Dusseldorf"],
             )
             .as_("start")
@@ -127,7 +127,7 @@ class TestSteps(BaseTest):
             self.g.V()
             .has_label("airport")
             .within(
-                ["properties", "city"],
+                "city",
                 ["Brussels", "Maastricht", "Aachen", "Dusseldorf"],
             )
             .as_("start")

--- a/tests/test_live_demo.py
+++ b/tests/test_live_demo.py
@@ -1,9 +1,6 @@
 import unittest
-
 from mogwai.core.traversal import MogwaiGraphTraversalSource
-
 from .basetest import BaseTest
-
 
 class TestLiveDemo(BaseTest):
     def setUp(self):
@@ -90,7 +87,6 @@ class TestLiveDemo(BaseTest):
         print("Result:", res)
         self.assertEqual(res[0], ["FRA", "Argentina", 7141], "Incorrect result")
 
-    @unittest.skip  # does not work as of 2024-08-15
     def test_from_nearby_airports(self):
         from mogwai.core.steps.statics import select
 
@@ -104,36 +100,7 @@ class TestLiveDemo(BaseTest):
             .as_("start")
             .outE("route")
             .as_("e")
-            .outV()
-            .in_("contains")
-            .has_label("country")
-            .as_("dest")
-            .order(desc=True)
-            .by(select("e").values("dist"))
-            .limit(5)
-            .select("start", "dest")
-            .to_list()
-            .by("name")
-        )
-        print("Query:", query.print_query())
-        res = query.run()
-        print("Result:", res)
-
-    @unittest.skip  # does not work as of 2024-08-15
-    def test_from_nearby_airports2(self):
-        from mogwai.core.steps.statics import select
-
-        query = (
-            self.g.V()
-            .has_label("airport")
-            .within(
-                "city",
-                ["Brussels", "Maastricht", "Aachen", "Dusseldorf"],
-            )
-            .as_("start")
-            .outE("route")
-            .as_("e")
-            .outV()
+            .inV()
             .in_("contains")
             .has_label("country")
             .as_("dest")
@@ -156,7 +123,7 @@ class TestLiveDemo(BaseTest):
         query = (
             g.V()
             .has_label("airport")
-            .has_property("city", "Maastricht")
+            .has("city", "Maastricht")
             .as_("start")
             .repeat(
                 outE("route")

--- a/tests/test_mogwaigraph.py
+++ b/tests/test_mogwaigraph.py
@@ -6,7 +6,7 @@ from mogwai.core.mogwaigraph import MogwaiGraph
 from .basetest import BaseTest
 
 
-class TestNetworkX(BaseTest):
+class TestMogwaiGraph(BaseTest):
     def setUp(self):
         super().setUp()
         self.G = MogwaiGraph()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -5,7 +5,7 @@ from mogwai.parser import PDFGraph
 from .basetest import BaseTest
 
 
-class TestFileSystem(BaseTest):
+class TestPDF(BaseTest):
     def setUp(self):
         super().setUp()
         # Initialize a sample file system structure for testing
@@ -16,11 +16,11 @@ class TestFileSystem(BaseTest):
         nodes = graph.get_nodes("PDFFile", "lorem.pdf")
         self.assertTrue(len(nodes) == 1, "Incorrect number of lorem.pdf nodes")
         self.assertTrue(
-            nodes[0][1]["properties"]["metadata"]["creator"].startswith("LaTeX"),
+            nodes[0][1]["metadata"]["creator"].startswith("LaTeX"),
             "'Creator' field of metadata incorrect.",
         )
         self.assertTrue(
-            graph.get_nodes("PDFTitle", "discussion")[0][1]["properties"]["page_number"]
+            graph.get_nodes("PDFTitle", "discussion")[0][1]["page_number"]
             == 3,
             "Discussion at wrong place",
         )

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -5,7 +5,7 @@ from mogwai.parser.powerpoint_converter import PPGraph
 from .basetest import BaseTest
 
 
-class TestGraph(BaseTest):
+class TestPowerPoint(BaseTest):
     def setUp(self):
         super().setUp()
         # Initialize a sample file system structure for testing
@@ -15,16 +15,15 @@ class TestGraph(BaseTest):
     def test_pp(self):
         graph = PPGraph(self.filename)
         nodes = graph.get_nodes("PPFile", "test_pp1.pptx")
-        self.assertTrue(len(nodes) == 1, "Incorrect number of test_pp1.pptx nodes")
+        self.assertEqual(len(nodes), 1, "Incorrect number of test_pp1.pptx nodes")
         self.assertTrue(
-            nodes[0][1]["properties"]["metadata"]["author"].startswith("Musselman"),
+            nodes[0][1]["metadata"]["author"].startswith("Musselman"),
             "'author' field of metadata incorrect.",
         )
-        self.assertTrue(
-            graph.get_nodes("PPPage", "page2")[0][1]["properties"]["title"]
-            == "Resources",
-            "Title wrong",
-        )
+        nodes = graph.get_nodes("PPPage", "page2")
+        self.assertGreater(len(nodes), 0, "No slide named 'Resources'")
+        self.assertEqual(nodes[0][1]["title"], "Resources", "Title wrong" )
+        self.assertEqual(nodes[0][1]["page"], 2,"Page number wrong")
         graph.draw(os.path.join(self.root_path, "tests", "pp_test.svg"), "dot")
         g = PPGraph(self.midterm)
         g.draw(os.path.join(self.root_path, "tests", "midterm.svg"), "dot")

--- a/tests/test_traverser.py
+++ b/tests/test_traverser.py
@@ -77,7 +77,6 @@ class TestTraverser(BaseTest):
         res2 = query2.run()
         self.assertEqual(set(res2), set(res), "Query result incorrect")
 
-    @unittest.skip("needs fix")  # does not works as of 2024-08-15
     def test_cache_and_select(self):
         g = Trav.MogwaiGraphTraversalSource(self.modern)
         query = g.V().out().as_("a").out().select("a", by="name").to_list()

--- a/tests/test_traverser.py
+++ b/tests/test_traverser.py
@@ -214,6 +214,24 @@ class TestTraverser(BaseTest):
         self.assertTrue(res[0]  in ["lop", "ripple"], "Query result incorrect")
     """
 
+    def test_addV_and_addE(self):
+        g = Trav.MogwaiGraphTraversalSource(self.modern)
+        query = g.addV("Person", name="john", age=30).next()
+        print(f"Query: {query.print_query()}")
+        john = query.run()
+        print(f"Result: {john}")
+        self.assertEqual(g.V().count().next().run(), 7, "Node not added to graph")
+
+        vadas = g.V().has_name("vadas").next().run()
+        query = g.addE("knows").from_(john).to_(vadas).property("likes", True).iterate()
+        print(f"Query: {query.print_query()}")
+        query.run()
+        query = g.E().properties('likes').next()
+        print(f"Query: {query.print_query()}")
+        res = query.run()
+        print(f"Result: {res}")
+        self.assertEqual(res, {"likes": True}, "Node not added to graph")
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_traverser.py
+++ b/tests/test_traverser.py
@@ -139,9 +139,9 @@ class TestTraverser(BaseTest):
         query = g.V().has_label("Person").property("City", "Aachen").run()
         for node in g.V().has_label("Person").to_list().run():
             data = self.modern.nodes(data=True)[node]
-            print(f"{data['name']} -> City: {data['properties']['City']}")
+            print(f"{data['name']} -> City: {data['City']}")
             self.assertEqual(
-                data["properties"]["City"],
+                data["City"],
                 "Aachen",
                 "SideEffect did not set city to Aachen",
             )

--- a/time_queries.py
+++ b/time_queries.py
@@ -45,7 +45,7 @@ def query_grempy_Lax(g:GraphTraversalSource):
 def query_mogwai_furthest(g:MogwaiGraphTraversalSource):
     from mogwai.core.steps.statics import select
     from gremlin_python.process.graph_traversal import __
-    res = g.V().has_label("airport").within(["properties","city"], ["Brussels", "Maastricht", "Aachen", "Dusseldorf"]).as_('start')\
+    res = g.V().has_label("airport").within("city", ["Brussels", "Maastricht", "Aachen", "Dusseldorf"]).as_('start')\
         .outE("route").as_("e").inV().in_("contains").has_label("country").as_('dest')\
         .order(desc=True).by(select('e').properties('dist'))\
         .limit(5).select('start', 'dest').by('desc').to_list()

--- a/todo.txt
+++ b/todo.txt
@@ -1,22 +1,10 @@
 implement the following steps:
-x local
 - fold
-x multiple by's
-x multiple keys in value
-x values
-x hasNot
-x has with three keys
-x hasNext
-x hasId with multiple IDs
 - hasLabel with multiple IDs
 - hasName with multiple IDs
-x hasKey
-x hasValue
 - predicates
     - between
     - within
-x skip
-x range
 - valueMap
-x build method
-x eager execution
+- properties should not return 'properties' itself
+- elementMap

--- a/todo.txt
+++ b/todo.txt
@@ -1,10 +1,5 @@
 implement the following steps:
 - fold
-- hasLabel with multiple IDs
-- hasName with multiple IDs
-- predicates
-    - between
-    - within
+- unfold
 - valueMap
-- properties should not return 'properties' itself
-- elementMap
+- elementMap properly


### PR DESCRIPTION
Since our design choice to include all node and edge attributes in a dictionary stored under the key 'properties' in the node/edge dicts proved make things unnecessarily complicated and stand in the way of Gremlin compatibility, I removed the nested 'properties' dictionary. Now, all attributes are stored directly in the dictionary of the nodes/edges of the NetworkX graph.

Additionally, I added several more steps.